### PR TITLE
Clean up before removing unused DSP node

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -309,6 +309,7 @@ $(async () => {
             }
             dsp.disconnect();
             audioEnv.dspConnectedToOutput = false;
+            dsp.destroy();
             delete audioEnv.dsp;
         }
         /**
@@ -1376,6 +1377,7 @@ $(async () => {
             }
             dsp.disconnect();
             audioEnv.dspConnectedToOutput = false;
+            dsp.destroy();
             delete audioEnv.dsp;
         }
         if ($("#tab-faust-ui").hasClass("active")) $("#tab-diagram").tab("show");


### PR DESCRIPTION
For better performance with Firefox, see https://github.com/grame-cncm/faust2webaudio/pull/5#issuecomment-564687802