### PR TITLE
make npm run dist work as expected

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "src/index.ts",
   "scripts": {
     "prebuild": "node ./src/cleanup.js && node ./src/listEx.js && node ./src/faust-ui.js && node ./src/faust-libfaust.js",
-    "build": "npm run prebuild && webpack --mode development",
-    "dist": "npm run prebuild && node ./src/faust-ui.js && node ./src/faust-libfaust.js && webpack --mode production",
+    "build": "webpack --mode development",
+    "dist": "npm run prebuild && webpack --mode production",
     "publish": "rm -rf docs/* && git checkout docs/CNAME && cp -r dist/* docs",
     "version": "npm run build"
   },


### PR DESCRIPTION
For issue #11 
Now `dist` emits files as expected. However, `build` is much faster then `dist` as it doesn't minify JS files, which is recommended and so as the `index.html` is configured. If decided to use `dist`, line 26 `src="index.js"` of `index.html` should be changed to `src="index.min.js"`.
PS: I realized that `npm run build` will call automatically `prebuild` by default.
@dfober 