### PR TITLE
improved file input and error handling

### DIFF
--- a/src/FileManager.ts
+++ b/src/FileManager.ts
@@ -81,7 +81,7 @@ export class FileManager {
         this.saveHandler = options.saveHandler;
         this.deleteHandler = options.deleteHandler;
         this.mainFileChangeHandler = options.mainFileChangeHandler;
-        this.errorHandler = options.errorHandler;
+        this.errorHandler = options.errorHandler || (() => undefined);
         this.getChildren();
         this.getFiles();
         this.bind();

--- a/src/FileManager.ts
+++ b/src/FileManager.ts
@@ -1,4 +1,5 @@
 import "./FileManager.scss";
+import { isAudioFile, readFileContent } from "./audioFileUtils";
 
 type TOptions = {
     container: HTMLDivElement;
@@ -9,6 +10,7 @@ type TOptions = {
     saveHandler?: (name: string, content: string | Uint8Array, mainCode: string) => any;
     deleteHandler?: (name: string, mainCode: string) => any;
     mainFileChangeHandler?: (name: string, mainCode: string) => any;
+    errorHandler?: (message: string) => any;
 };
 type TFileSystem = {
     rename: (oldName: string, newName: string) => any;
@@ -69,6 +71,7 @@ export class FileManager {
     saveHandler: (name: string, content: string | Uint8Array, mainCode: string) => any = () => undefined;
     deleteHandler?: (name: string, mainCode: string) => any = () => undefined;
     mainFileChangeHandler?: (name: string, mainCode: string) => any = () => undefined;
+    errorHandler?: (message: string) => any = () => undefined;
 
     constructor(options: TOptions) {
         this.container = options.container;
@@ -78,6 +81,7 @@ export class FileManager {
         this.saveHandler = options.saveHandler;
         this.deleteHandler = options.deleteHandler;
         this.mainFileChangeHandler = options.mainFileChangeHandler;
+        this.errorHandler = options.errorHandler;
         this.getChildren();
         this.getFiles();
         this.bind();
@@ -200,15 +204,10 @@ export class FileManager {
                 e.preventDefault();
                 e.stopPropagation();
                 const file = e.dataTransfer.files[0];
-                const reader = new FileReader();
-                reader.onload = () => {
-                    const content = typeof reader.result === "string" ? reader.result.toString() : new Uint8Array(reader.result);
+                readFileContent(file).then((content) => {
                     const fileName = this.newFile(file.name, content);
                     this.select(fileName);
-                };
-                reader.onerror = () => undefined;
-                if (file.name.match(/\.(wav|mp3|ogg|flac|aac)$/)) reader.readAsArrayBuffer(file);
-                else reader.readAsText(file);
+                }).catch((err) => this.errorHandler(err.message));
             }
         };
         this.container.addEventListener("dragenter", dragenterHandler);
@@ -303,7 +302,7 @@ process = ba.pulsen(1, 10000) : pm.djembe(60, 0.3, 0.4, 1) <: dm.freeverb_demo;`
      */
     setMain($: number) {
         if ($ >= this._fileList.length) return;
-        if (this._fileList[$].match(/\.(wav|mp3|ogg|flac|aac)$/)) return;
+        if (isAudioFile(this._fileList[$])) return;
         this.$mainFile = $;
         for (let i = 0; i < this.divFiles.children.length; i++) {
             const e = this.divFiles.children[i];
@@ -390,7 +389,7 @@ process = ba.pulsen(1, 10000) : pm.djembe(60, 0.3, 0.4, 1) <: dm.freeverb_demo;`
         return fileName;
     }
     select(fileName: string) {
-        if (fileName.match(/\.(wav|mp3|ogg|flac|aac)$/)) return;
+        if (isAudioFile(fileName)) return;
         for (let i = 0; i < this.divFiles.children.length; i++) {
             const divFile = this.divFiles.children[i] as HTMLDivElement;
             if (divFile.dataset.filename === fileName) divFile.classList.add("selected");
@@ -420,7 +419,7 @@ process = ba.pulsen(1, 10000) : pm.djembe(60, 0.3, 0.4, 1) <: dm.freeverb_demo;`
     }
     getValue(fileNameIn?: string) {
         const fileName = fileNameIn || this.selected;
-        if (fileNameIn.match(/\.(wav|mp3|ogg|flac|aac)$/)) return this.fs.readFile(this.path + fileName) as Uint8Array;
+        if (isAudioFile(fileName)) return this.fs.readFile(this.path + fileName) as Uint8Array;
         return this.fs.readFile(this.path + fileName, { encoding: "utf8" }) as string;
     }
     get selected() {

--- a/src/audioFileUtils.ts
+++ b/src/audioFileUtils.ts
@@ -1,0 +1,18 @@
+const AUDIO_EXTENSIONS = /\.(wav|mp3|ogg|flac|aac)$/i; //case insensitive
+
+export function isAudioFile(filename: string): boolean {
+    return AUDIO_EXTENSIONS.test(filename);
+}
+
+export function readFileContent(file: File): Promise<string | Uint8Array> {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+            if (typeof reader.result === "string") resolve(reader.result);
+            else resolve(new Uint8Array(reader.result));
+        };
+        reader.onerror = () => reject(new Error(`Failed to read file: ${file.name}`));
+        if (isAudioFile(file.name)) reader.readAsArrayBuffer(file);
+        else reader.readAsText(file);
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import { faustLangRegister } from "./monaco-faust/register";
 import * as VERSION from "./version";
 import { docSections, faustDocURL, faustSyntaxURL } from "./documentation";
 import { safeStorage } from "./utils";
+import { isAudioFile, readFileContent } from "./audioFileUtils";
 
 declare global {
     interface Window {
@@ -602,7 +603,8 @@ $(async () => {
             saveEditorParams();
             clearTimeout(rtCompileTimer);
             if (compileOptions.realtimeCompile) rtCompileTimer = setTimeout(audioEnv.dsp ? runDsp : updateDiagram, 100, mainCode);
-        }
+        },
+        errorHandler: (message) => showError(message)
     });
     if (compileOptions.saveDsp) loadEditorDspTable();
 
@@ -893,18 +895,15 @@ $(async () => {
     });
     $<HTMLInputElement>("#input-upload").on("input", (e) => {
         const file = e.currentTarget.files[0];
-        const reader = new FileReader();
-        reader.onload = () => {
+        if (!file) return;  // if upload cancelled
+        readFileContent(file).then((content) => {
             const fileName = file.name.replace(/[^a-zA-Z0-9_.]/g, "") || "untitled.dsp";
-            const code = reader.result.toString();
-            uiEnv.fileManager.newFile(fileName, code);
-            if (compileOptions.realtimeCompile) {
+            uiEnv.fileManager.newFile(fileName, content);
+            if (compileOptions.realtimeCompile && !isAudioFile(file.name)) {
                 if (audioEnv.dsp) runDsp(uiEnv.fileManager.mainCode);
                 else updateDiagram(uiEnv.fileManager.mainCode);
             }
-        };
-        reader.onerror = () => undefined;
-        reader.readAsText(file);
+        }).catch((err) => showError(`Could not read file "${file.name}": ${err.message}`));
     }).on("click", e => e.stopPropagation());
     // Save as zip
     $("#btn-save").on("click", async () => {
@@ -939,11 +938,9 @@ $(async () => {
             uiEnv.fileManager._fileList.forEach((n) => {
                 if (n.endsWith(".lib")) zip.file(n, uiEnv.fileManager.getValue(n));
             });
-            // Add all .wav or .flac audio files in the ZIP
+            // Add all audio files in the ZIP
             uiEnv.fileManager._fileList.forEach((n) => {
-                if (n.endsWith(".wav") || n.endsWith(".flac")) {
-                    zip.file(n, uiEnv.fileManager.getValue(n));
-                }
+                if (isAudioFile(n)) zip.file(n, uiEnv.fileManager.getValue(n));
             });
             // Add the currently selected .dsp file in the ZIP
             zip.file(`${name}.dsp`, `declare filename "${name}.dsp";\ndeclare name "${name}";\n${uiEnv.fileManager.mainCode}`);
@@ -1471,20 +1468,16 @@ $(async () => {
             e.preventDefault();
             e.stopPropagation();
             const file = event.dataTransfer.files[0];
-            const reader = new FileReader();
-            reader.onload = () => {
+            readFileContent(file).then((content) => {
                 // Update filename
                 const fileName = file.name.replace(/[^a-zA-Z0-9_.]/g, "") || "untitled.dsp";
-                const code = reader.result.toString();
-                uiEnv.fileManager.newFile(fileName, code);
+                uiEnv.fileManager.newFile(fileName, content);
                 // compile diagram or dsp if necessary
-                if (compileOptions.realtimeCompile) {
+                if (compileOptions.realtimeCompile && !isAudioFile(file.name)) {   // skip compile for audio files
                     if (audioEnv.dsp) runDsp(uiEnv.fileManager.mainCode);
                     else updateDiagram(uiEnv.fileManager.mainCode);
                 }
-            };
-            reader.onerror = () => undefined;
-            reader.readAsText(file);
+            }).catch((err) => showError(`Could not read file "${file.name}": ${err.message}`));
         }
     });
     // Examples

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -54,7 +54,7 @@
 					data-placement="right" title="Upload/Edit a local file">
 					<i class="fas fa-upload fa-sm"></i>
 					<span>Upload</span>
-					<input id="input-upload" type="file" type="file" />
+					<input id="input-upload" type="file" accept=".dsp,.lib,.wav,.mp3,.ogg,.flac,.aac" /> 
 				</button>
 				<button id="btn-save" type="button" class="btn btn-outline-secondary btn-sm" data-toggle="tooltip"
 					data-placement="right" title="Download/Save as a local file">


### PR DESCRIPTION
# In this PR
File upload and editor drag&drop handlers used readAsText() for all files, reading binary audio data as text, File read errors were also silent. This PR changes audio file handling into a reusable utility, fixes binary file corruption, and adds proper error feedback.

# Changes
 - New reusable utility `src/audioFileUtils.ts` 
   - with `AudioFile()` (now case-insensitive regex check) and `readFileContent()` (now returns string for code, Uint8Array for audiofiles).
 
 - in `FileManager.ts` 
   - Used `src/audioFileUtils.ts` to replace the inline regex checks with `isAudioFile()` and added Error Handling.

- In `index.ts`
  - Fixed binary corruption for Drag&Drop and upload handler
  - Added error handling for both handlers
  - Export now inlcudes mp3, ogg and aac
  - Early return guard for cancelled upload
  
- Some minor changes
  - Audio file regex check is now case insensitive  
  - Added accept in index.html for better UX, user can still switch file picker to All files
  - Audio files no longer recompile
  